### PR TITLE
chore/dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,3 +8,8 @@ updates:
     directory: /
     schedule:
       interval: daily
+    groups:
+      vitest:
+        patterns:
+          - vitest
+          - "@vitest/*"


### PR DESCRIPTION
- **Update dependencies (#314)**
- **Bump typescript from 5.6.3 to 5.7.2 (#315)**
- **Bump type-fest from 4.27.0 to 4.28.0 (#316)**
- **Bump @raviqqe/eslint-config from 4.1.4 to 4.1.5 (#317)**
- **Bump type-fest from 4.28.0 to 4.28.1 (#318)**
- **Bump @vitest/coverage-v8 from 2.1.5 to 2.1.6 (#319)**
- **Bump type-fest from 4.28.1 to 4.29.0 (#321)**
- **Bump @vitest/coverage-v8 from 2.1.6 to 2.1.7 (#322)**
- **Bump eslint from 9.15.0 to 9.16.0 (#324)**
- **Bump type-fest from 4.29.0 to 4.29.1 (#325)**
- **Bump type-fest from 4.29.1 to 4.30.0 (#326)**
- **Bump @vitest/coverage-v8 from 2.1.7 to 2.1.8 (#328)**
- **Bump @raviqqe/tsconfig from 1.1.0 to 1.2.0 (#329)**
- **Bump @raviqqe/eslint-config from 4.1.5 to 4.1.6 (#330)**
- **Bump type-fest from 4.30.0 to 4.30.1 (#331)**
- **Bump @raviqqe/eslint-config from 4.1.6 to 4.1.7 (#332)**
- **Bump eslint from 9.16.0 to 9.17.0 (#333)**
- **Bump type-fest from 4.30.1 to 4.30.2 (#334)**
- **Bump esbuild from 0.24.0 to 0.24.1 (#335)**
- **Bump esbuild from 0.24.1 to 0.24.2 (#336)**
- **Bump type-fest from 4.30.2 to 4.31.0 (#337)**
- **Bump typescript from 5.7.2 to 5.7.3 (#338)**
- **Bump type-fest from 4.31.0 to 4.32.0 (#339)**
- **Bump eslint from 9.17.0 to 9.18.0 (#340)**
- **Bump type-fest from 4.32.0 to 4.33.0 (#343)**
- **Update Dependabot configuration**
